### PR TITLE
Fixed crashing issue when selecting "can't find address" option 

### DIFF
--- a/src/Components/AddressInput.jsx
+++ b/src/Components/AddressInput.jsx
@@ -101,18 +101,12 @@ export default (address) => {
             {renderSuggestions()}
           </ComboboxList>
         ) : (
-          <ComboboxList>
-            <ComboboxOption
-              value={
-                <div>
-                  <span aria-label="embaressed face emoji" role="img">
-                    😳
-                  </span>
-                  &nbsp;We couldn't find that address! Please try another.
-                </div>
-              }
-            />
-          </ComboboxList>
+          <div>
+            <span aria-label="embaressed face emoji" role="img">
+              😳
+            </span>
+            &nbsp;We couldn't find that address! Please try another.
+          </div>
         )}
       </StyledComboboxPopover>
     </Combobox>


### PR DESCRIPTION
by making it not selectable